### PR TITLE
fix(#3): last opened project save

### DIFF
--- a/src/app/storages/global.ts
+++ b/src/app/storages/global.ts
@@ -124,6 +124,7 @@ export const useGlobalStore = defineStore('global', () => {
         const nextProject = projects.value.find((project: Project) => project.name === projectName);
         if (nextProject) {
             projectStore.hydrate(nextProject.name, slugify(nextProject.name), nextProject.templates);
+            save();
         }
     }
 


### PR DESCRIPTION
The last project which was opened during the last session will now properly be the default opened project for the next session.